### PR TITLE
Add unified pos command with Tkinter UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.log


### PR DESCRIPTION
## Summary
- merge region configuration into a single `pos` command
- provide a Tkinter based UI for selecting question and answer regions
- update help text, startup commands and command loop accordingly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 rich_test.py` *(fails: ModuleNotFoundError: No module named 'rich')*


------
https://chatgpt.com/codex/tasks/task_e_6861fab2327083298c64780aa25dad82