### PR TITLE
Add setter for ConfigManager data property

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -24,6 +24,17 @@ class ConfigManager:
         """
         return self._data
 
+    @data.setter
+    def data(self, value: Dict) -> None:
+        """Replace the configuration data.
+
+        Using a setter allows callers to assign a new configuration
+        dictionary to the manager.  The provided value completely
+        replaces the existing configuration, so callers should ensure
+        any required keys are present before saving.
+        """
+        self._data = value
+
     def default_config(self) -> Dict:
         return {
             'question_region': {'x': 115, 'y': 680, 'width': 680, 'height': 200},


### PR DESCRIPTION
## Summary
- allow configuration data to be replaced by adding a setter to `ConfigManager.data`
- document the setter behavior

## Testing
- `python - <<'PY'
import config_manager
cm = config_manager.ConfigManager()
config = cm.data
config['active_database'] = 'magic'
cm.data = config
print('Active database:', cm.data['active_database'])
PY`
- `pytest -q` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_6898e2dc09c08329be8173a6042c2e92