### PR TITLE
feat: make logging level configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ python cli.py config    # show configuration
 
 Configuration is stored in `config.json`. Edit it manually or use commands in the interactive shell.
 
+Set the `log_level` field in `config.json` to control console logging. Use values like `"WARNING"` or `"ERROR"` to suppress
+informational messages.
+

--- a/accuracy_evaluator.py
+++ b/accuracy_evaluator.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Any
 
+from config_manager import ConfigManager
+
 # --- Removed sklearn imports as TF-IDF is no longer used ---
 # from sklearn.feature_extraction.text import TfidfVectorizer
 # from sklearn.metrics.pairwise import cosine_similarity
@@ -54,24 +56,30 @@ except ImportError:
     print("Install it using: pip install editdistance")
 # --- Optional Reporting Libraries end ---
 
-# --- Logging Setup ---
-log_file = Path("accuracy_evaluator.log")
+# --- Path and Logging Setup ---
+PROJECT_ROOT = Path(__file__).parent.resolve()
+CONFIG_FILE = PROJECT_ROOT / 'config.json'
+log_file = PROJECT_ROOT / 'accuracy_evaluator.log'
+
+config_manager = ConfigManager(str(CONFIG_FILE))
+config = config_manager.data
+
+log_level_name = config.get('log_level', 'INFO').upper()
+log_level = getattr(logging, log_level_name, logging.INFO)
 logging.basicConfig(
-    level=logging.INFO,
+    level=log_level,
     format='%(asctime)s - %(levelname)s - %(message)s',
     handlers=[
         logging.FileHandler(log_file),
-        logging.StreamHandler() # Also print logs to console
+        logging.StreamHandler()  # Also print logs to console
     ]
 )
 logger = logging.getLogger(__name__)
-# --- Logging Setup end ---
+# --- Path and Logging Setup end ---
 
 # --- Global Variables & Constants ---
-PROJECT_ROOT = Path(__file__).parent.resolve()
 ALL_CAPTURES_DIR = PROJECT_ROOT / "all_captures"
 REPORTS_DIR = PROJECT_ROOT / "accuracy_reports"
-CONFIG_FILE = PROJECT_ROOT / 'config.json'
 # --- Changed from DATABASE_FILE to GROUND_TRUTH_FILE ---
 GROUND_TRUTH_FILE = PROJECT_ROOT / 'compare.json' # Using compare.json as ground truth
 # --- Changed end ---

--- a/config.json
+++ b/config.json
@@ -42,5 +42,6 @@
     "filter_answer_choice_tags": false,
     "save_all_captured_images": false,
     "active_database": "all",
-    "filter_selected_pattern": true
+    "filter_selected_pattern": true,
+    "log_level": "INFO"
 }

--- a/config_manager.py
+++ b/config_manager.py
@@ -52,7 +52,8 @@ class ConfigManager:
             'filter_answer_choice_tags': False,
             'save_all_captured_images': False,
             'active_database': 'default',
-            'filter_selected_pattern': True
+            'filter_selected_pattern': True,
+            'log_level': 'INFO'
         }
 
     def load(self) -> Dict:

--- a/terminal_app.py
+++ b/terminal_app.py
@@ -34,6 +34,23 @@ from rich.text import Text
 from rich.box import Box, ROUNDED, SIMPLE
 console = Console()
 
+# Configuration file path
+CONFIG_FILE = 'config.json'
+config_manager = ConfigManager(CONFIG_FILE)
+config = config_manager.data
+
+# Set up logging based on configuration
+log_level_name = config.get('log_level', 'INFO').upper()
+log_level = getattr(logging, log_level_name, logging.INFO)
+logging.basicConfig(
+    level=log_level,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler('terminal_app.log'),
+        logging.StreamHandler()
+    ]
+)
+
 # Try to import torch for GPU memory management
 try:
     import torch
@@ -48,19 +65,6 @@ try:
 except ImportError:
     HAS_WIN32 = False
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler('terminal_app.log'),
-        logging.StreamHandler()
-    ]
-)
-
-# Configuration file path
-CONFIG_FILE = 'config.json'
-
 # Global variables
 ocr_processor = None
 questions_df = None
@@ -69,7 +73,6 @@ recognized_text = {}
 best_match = None
 tfidf_vectorizer = None
 tfidf_matrix = None
-config = None
 timings = {}
 auto_click = False  # Whether to automatically click on the answer
 question_capture_count = 0 # New global counter for captured questions
@@ -84,9 +87,6 @@ capture_lock = threading.Lock()
 debug_dir = Path('debug_images')
 debug_dir.mkdir(exist_ok=True)
 # --- Debug Directory end ---
-
-config_manager = ConfigManager(CONFIG_FILE)
-config = config_manager.data
 
 def capture_screen(region):
     """Capture a specific region of the screen"""


### PR DESCRIPTION
## Summary
- add `log_level` setting to config and default configuration
- allow terminal app and accuracy evaluator to honor the configured log level
- document logging option in README

## Testing
- `python -m py_compile terminal_app.py accuracy_evaluator.py config_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6898e9e26db48329badcabb007c2f66f